### PR TITLE
Remove "built on" message to allow reproducible build.

### DIFF
--- a/src/wmcoincoin.c
+++ b/src/wmcoincoin.c
@@ -2022,7 +2022,7 @@ int main(int argc, char **argv)
 
   _dock = dock; /* la vilaine variable globale (pour les sighandlers) */
 
-  myprintf(_("%<GRN wmc2> v.%<WHT %s> [ built on %s ]\n"),VERSION, __DATE__);
+  myprintf(_("%<GRN wmc2> v.%<WHT %s>\n"),VERSION);
 
   /* contruit un useragent qui ignore la partie terminale du numero de version
      ( '2.3.6f' --> '2.3.6') */


### PR DESCRIPTION
The "built on" message that is displayed upon startup used the __DATE__ macro.
However, this means that subsequent builds will produce binaries which differ,
which is discouraged in Debian [1].

[1] https://wiki.debian.org/ReproducibleBuilds