### PR TITLE
wmcoincoin_player: check return-value of XOpenDisplay during initialization

### DIFF
--- a/platypus/wmcoincoin_player.c
+++ b/platypus/wmcoincoin_player.c
@@ -103,7 +103,12 @@ main (int argc, char **argv)
    init_prefs();
    init_anim();
 
-   disp  = XOpenDisplay(NULL);
+   disp = XOpenDisplay(NULL);
+   if (disp == NULL) {
+     fputs("Couldn't connect to display\n", stderr);
+     return 1;
+   }
+
    if (argc == 1) {
      printf("kikou je suis un player pourri\n");
      printf("mes options toutes plus nazes les unes que les autres sont:\n");


### PR DESCRIPTION
It may return NULL, in which case the application should report the error and
exit, rather than just crashing.